### PR TITLE
fix(popup): checkbox dikey hizalama + refresh ikonu dönme animasyonu

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -213,6 +213,16 @@ body {
   transform: scale(0.9);
 }
 
+/* Modelleri yenile: fetch sırasında ikon döner */
+@keyframes lct-spin {
+  to { transform: rotate(360deg); }
+}
+
+.btn-icon.spinning svg {
+  animation: lct-spin 0.7s linear infinite;
+  transform-origin: center;
+}
+
 .status {
   font-size: 11px;
   margin-top: 4px;
@@ -407,6 +417,8 @@ body {
 }
 
 .checkbox-row label {
+  display: flex;
+  align-items: center;
   margin: 0;
   font-size: 11px;
   gap: 5px;

--- a/popup.js
+++ b/popup.js
@@ -330,8 +330,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   els.refreshModels.addEventListener('click', async () => {
+    els.refreshModels.classList.add('spinning');
     setModelStatus('popup.model.loading', '');
-    await loadModels(true);
+    try {
+      await loadModels(true);
+    } finally {
+      els.refreshModels.classList.remove('spinning');
+    }
   });
 
   // Varsayılana sıfırla (API key hariç)


### PR DESCRIPTION
- .checkbox-row label display:flex + align-items:center: custom checkbox kutusu artık label metniyle dikey ortalı (baseline kayması giderildi).
- Modelleri yenile butonu: tıklanınca SVG döner (lct-spin keyframe + spinning class). loadModels bitince finally ile durur.

## Açıklama

<!-- Bu PR ne yapıyor? Kısaca açıklayın. -->

## İlgili Issue

<!-- Varsa ilgili issue numarasını yazın: fixes #123 -->

## Değişiklik Türü

- [ ] Hata düzeltme
- [ ] Yeni özellik
- [ ] İyileştirme
- [ ] Refaktör
- [ ] Dokümantasyon
- [ ] Diğer

## Yapılan Değişiklikler

<!-- Değişiklikleri madde madde listeleyin -->

-

## Test

- [ ] Eklenti Chrome'a başarıyla yüklendi
- [ ] En az bir Laracasts videosunda manuel test yapıldı
- [ ] Çeviri doğru çalışıyor
- [ ] Popup ayarları doğru çalışıyor
- [ ] Konsol'da hata yok
- [ ] Mevcut işlevsellik bozulmadı

## Ekran Görüntüleri

<!-- Varsa değişiklikleri gösteren ekran görüntüleri ekleyin -->

## Kod Kuralları Uyumu

- [ ] Kod yorumları ve UI metinleri Türkçe
- [ ] Türkçe karakterler UTF-8 olarak korunuyor
- [ ] Harici kütüphane eklenmedi (vanilla JS)
- [ ] Content script'ler IIFE ile izole
- [ ] Manifest V3 API'leri kullanıldı
